### PR TITLE
Fix runtime version output

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from 'child_process';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('CLI metadata', () => {
+  let packageDir: string;
+
+  beforeEach(() => {
+    packageDir = mkdtempSync(join(tmpdir(), 'contextmesh-cli-test-'));
+    cpSync(join(__dirname, '..', '..', 'dist'), join(packageDir, 'dist'), { recursive: true });
+
+    const packageJson = JSON.parse(
+      readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8')
+    );
+    packageJson.version = '1.2.3';
+    writeFileSync(join(packageDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+  });
+
+  afterEach(() => {
+    rmSync(packageDir, { recursive: true, force: true });
+  });
+
+  it('prints the runtime package version', () => {
+    const result = spawnSync(process.execPath, [join(packageDir, 'dist', 'cli.js'), '--version'], {
+      cwd: packageDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NODE_PATH: join(__dirname, '..', '..', 'node_modules'),
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('1.2.3');
+    expect(result.stderr).toBe('');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,14 +1,27 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { publishCommand } from './commands/publish';
+
+function getPackageVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
+    );
+    return packageJson.version;
+  } catch {
+    return '0.1.0';
+  }
+}
 
 const program = new Command();
 
 program
   .name('contextmesh')
   .description('CLI tool for ContextMesh - npm-like package manager for MCP connectors')
-  .version('0.1.0');
+  .version(getPackageVersion());
 
 // Add commands
 program.addCommand(publishCommand);


### PR DESCRIPTION
## Summary

Fixes #14.

The CLI currently hardcodes `.version('0.1.0')`, so release-published packages can report stale metadata. The current npm package `@contextmesh/cli@1.0.0` prints `0.1.0` for `contextmesh --version`.

This PR:

- reads the version from the runtime package's `package.json`,
- keeps `0.1.0` as a fallback for unusual local/runtime cases,
- adds a Jest CLI smoke test that simulates a release package version differing from the source checkout version.

## Verification

```sh
npm run build
npx jest src/__tests__/cli.test.ts --runInBand
npm test -- --runInBand
npm run typecheck
npm run lint:check
npm pack --pack-destination /tmp/earn-micro-scan/contextmesh-pack
```

Notes:

- `npm run lint:check` exits 0; it still reports the existing `no-explicit-any` warnings in unrelated files.
- `npm ci` currently fails on `main` because `package-lock.json` is missing optional esbuild/fsevents entries expected by current npm. I used `npm install --ignore-scripts --no-audit --no-fund` to build the local verification environment and did not commit lockfile churn.

Fresh install smoke from a packed tarball whose `package.json` version was set to `1.0.0`:

```text
contextmesh --version -> 1.0.0
package.json version -> 1.0.0
```
